### PR TITLE
feat: types now behave as real functions

### DIFF
--- a/src/base-type.ts
+++ b/src/base-type.ts
@@ -459,6 +459,8 @@ export abstract class BaseObjectLikeTypeImpl<ResultType> extends BaseTypeImpl<Re
     }
 }
 
+const FUNCTION_PROTOTYPE_DESCRIPTORS = Object.getOwnPropertyDescriptors(Function.prototype);
+
 /**
  * Create a Type from the given type-implementation.
  *
@@ -478,6 +480,7 @@ export function createType<Impl extends BaseTypeImpl<any>>(
     const type = Object.defineProperties(
         Object.setPrototypeOf((input: unknown) => type.construct(input) as unknown, Object.getPrototypeOf(impl)),
         {
+            ...FUNCTION_PROTOTYPE_DESCRIPTORS,
             ...Object.getOwnPropertyDescriptors(impl),
             ...override,
             _instanceCache: { configurable: true, value: {} },

--- a/src/testutils.ts
+++ b/src/testutils.ts
@@ -60,6 +60,9 @@ export function testTypeImpl({
         validConversions &&
             test.each(validConversions)('converting input %p into %p', (input, output) => {
                 expect(type(input)).toEqual(output);
+                expect(type.apply(undefined, [input])).toEqual(output);
+                expect(type.bind(undefined, input)()).toEqual(output);
+                expect(type.call(undefined, input)).toEqual(output);
             });
 
         invalidConversions &&


### PR DESCRIPTION
All types now provide the `call`, `apply` and `bind` methods as indicated by the TypeScript typings.