### PR TITLE
fix: `number.autoCast` converted any string with only whitespace characters into `0` per ES spec

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ const config = {
     coverageThreshold: {
         global: {
             statements: 99,
-            branches: 95,
+            branches: 96,
             functions: 98,
             lines: 99,
         },

--- a/src/types/literal.test.ts
+++ b/src/types/literal.test.ts
@@ -55,7 +55,7 @@ testTypeImpl({
     name: '"specific string".autoCast',
     type: literal('specific string').autoCast,
     validValues: ['specific string'],
-    invalidValues: [[{ toString: () => 'specific string' }, 'expected a string ("specific string"), got an object (specific string)']],
+    invalidValues: [[{ toString: () => 'specific string' }, 'expected a string ("specific string"), got an object ("specific string")']],
     validConversions: [[{ toString: () => 'specific string' }, 'specific string']],
 });
 

--- a/src/types/number.test.ts
+++ b/src/types/number.test.ts
@@ -10,6 +10,9 @@ testTypeImpl({
         ['123', basicTypeMessage(number, '123')],
         [NaN, defaultMessage(number, NaN)],
         ['', basicTypeMessage(number, '')],
+        [' ', basicTypeMessage(number, ' ')],
+        ['_', basicTypeMessage(number, '_')],
+        ['\n\r\v\t\f', basicTypeMessage(number, '\n\r\v\t\f')],
         ...defaultUsualSuspects(number),
     ],
 });
@@ -22,6 +25,7 @@ testTypeImpl({
         [NaN, defaultMessage(int, NaN, number)],
         ['a string', basicTypeMessage(int, 'a string', number)],
         ['', basicTypeMessage(int, '', number)],
+        [' ', basicTypeMessage(int, ' ', number)],
         [-10.5, defaultMessage(int, -10.5)],
         [10.123, defaultMessage(int, 10.123)],
         [-Infinity, defaultMessage(int, -Infinity)],
@@ -38,6 +42,7 @@ testTypeImpl({
         ['123', basicTypeMessage(number.autoCast, '123')],
         [NaN, defaultMessage(number.autoCast, NaN)],
         ['', basicTypeMessage(number.autoCast, '')],
+        [' ', basicTypeMessage(number.autoCast, ' ')],
     ],
     validConversions: [
         [123, 123],
@@ -46,6 +51,10 @@ testTypeImpl({
     ],
     invalidConversions: [
         ['', 'error in parser of [number.autoCast]: could not autocast value: ""'],
+        [' ', 'error in parser of [number.autoCast]: could not autocast value: " "'],
+        ['\n\r\v\t\f', 'error in parser of [number.autoCast]: could not autocast value: "\\n\\r\\u000b\\t\\f"'],
+        [{ toString: () => ' ' }, 'error in parser of [number.autoCast]: could not autocast value: " "'],
+        ['_', 'error in parser of [number.autoCast]: could not autocast value: "_"'],
         ['abc', 'error in parser of [number.autoCast]: could not autocast value: "abc"'],
         [NaN, 'error in parser of [number.autoCast]: could not autocast value: NaN'],
     ],

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -13,6 +13,19 @@ export type int = The<typeof int>;
 export const int: Type<Branded<number, 'int'>> = number.withConstraint('int', Number.isInteger);
 
 export function numberAutoCaster(input: unknown): number | typeof autoCastFailure {
-    const nr = typeof input === 'number' ? input : input === '' ? NaN : +String(input);
+    let nr;
+    if (typeof input === 'number') {
+        nr = input;
+    } else {
+        const str = String(input);
+        // Make sure we have at least one "meaningful" character in the string (because whitespaces are converted to `0`, thanks a lot
+        // JavaScript: https://tc39.es/ecma262/#sec-tonumber-applied-to-the-string-type). All possible numbers always have at least one
+        // of a-z or 0-9 in them (e.g. "Infinity", ".5", "3e15"), so we just need to look for one and let the Number conversion handle
+        // the rest.
+        if (!/\w/.test(str)) {
+            return autoCastFailure;
+        }
+        nr = +str;
+    }
     return Number.isNaN(nr) ? autoCastFailure : nr;
 }

--- a/src/utils/print-utils.ts
+++ b/src/utils/print-utils.ts
@@ -43,7 +43,7 @@ export function printValue(input: unknown, budget = 50, visited: Set<unknown> = 
                       })} }`
                     : '{}';
             }
-            return truncateString(String(input), budget);
+            return printValue(String(input), budget, visited);
     }
 }
 

--- a/src/validation-error.test.ts
+++ b/src/validation-error.test.ts
@@ -10,11 +10,11 @@ describe(ValidationError, () => {
     const CASES: [failure: Omit<Failure, 'ok'>, expected: Partial<ValidationError>][] = [
         [
             { type, input, details: [{ type, input }] },
-            { message: 'expected a [GreatType], got: [custom string]', type, input },
+            { message: 'expected a [GreatType], got: "[custom string]"', type, input },
         ],
         [
             { type, input, details: [{ type, input, kind: 'custom message', message: 'custom message, hurray' }] },
-            { message: 'error in [GreatType]: custom message, hurray, got: [custom string]', type, input },
+            { message: 'error in [GreatType]: custom message, hurray, got: "[custom string]"', type, input },
         ],
         [
             {


### PR DESCRIPTION
ES spec specifies that the ToNumber conversion should convert a string with whitespaces to `0`, that is not what we want. `number.autoCast` failed to identify those cases, which is fixed in this bugfix.