### PR TITLE
fix: remove peer dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,5 @@
         "@types/big.js": "^6.2.0",
         "big.js": "^6.2.1",
         "tslib": "^2.6.2"
-    },
-    "peerDependencies": {
-        "typescript": ">=5.1"
     }
 }


### PR DESCRIPTION
Peer dependencies in package.json only work for runtime dependencies, and typescript is not a runtime dependency of @skunkteam/types.