### PR TITLE
fix: no more warning for overlapping properties with exact same type

### DIFF
--- a/src/types/intersection.test.ts
+++ b/src/types/intersection.test.ts
@@ -6,6 +6,7 @@ import { object, partial } from './interface';
 import { IntersectionOfTypeTuple, intersection } from './intersection';
 import { literal } from './literal';
 import { number } from './number';
+import { string } from './string';
 import { union } from './union';
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -82,6 +83,8 @@ describe(intersection, () => {
     test('invalid type defs', () => {
         jest.spyOn(console, 'warn').mockReturnValueOnce();
         intersection([object({ a: number }), object({ a: number })]);
+        expect(console.warn).not.toHaveBeenCalled();
+        intersection([object({ a: number }), object({ a: string })]);
         expect(console.warn).toHaveBeenCalledWith(
             'overlapping properties are currently not supported in intersections, overlapping properties: a',
         );

--- a/src/types/intersection.ts
+++ b/src/types/intersection.ts
@@ -6,6 +6,7 @@ import type {
     Properties,
     PropertiesInfo,
     Result,
+    Type,
     TypeImpl,
     ValidationOptions,
     Visitor,
@@ -101,12 +102,16 @@ define(IntersectionType, 'createAutoCastAllType', function (this: IntersectionTy
 });
 
 function checkOverlap(types: OneOrMore<BaseObjectLikeTypeImpl<unknown>>) {
-    const keys = new Set<string>();
+    const keys = new Map<string, Type<any>>();
     const overlap = new Set<string>();
     for (const type of types) {
-        for (const key of Object.keys(type.props)) {
-            if (keys.has(key)) overlap.add(key);
-            keys.add(key);
+        for (const [key, propType] of Object.entries(type.props)) {
+            const prevPropType = keys.get(key);
+            if (!prevPropType) {
+                keys.set(key, propType);
+            } else if (prevPropType !== propType) {
+                overlap.add(key);
+            }
         }
     }
     if (overlap.size)


### PR DESCRIPTION
When using an intersection over several object-like types, overlapping properties can be dangerous. That is why a warning is logged to the console when that occurs. This warning is now suppressed when all definitions of the same property have the exact same type (reference equality).