### PR TITLE
feat: Change `string.autoCast` behaviour on anything other than booleans and numbers

### DIFF
--- a/src/types/record.test.ts
+++ b/src/types/record.test.ts
@@ -65,7 +65,7 @@ testTypeImpl({
     ],
     validConversions: [
         [{ 1: 1 }, { 1: '1' }],
-        [{ 123: Symbol('456') }, { 123: 'Symbol(456)' }],
+        [{ 123: false }, { 123: 'false' }],
     ],
 });
 

--- a/src/types/string.test.ts
+++ b/src/types/string.test.ts
@@ -92,9 +92,19 @@ testTypeImpl({
     basicType: 'string',
     validValues: ['', '123'],
     validConversions: [
-        [Symbol('abc'), 'Symbol(abc)'],
+        [false, 'false'],
         [123, '123'],
-        [{ toString: () => 'ok' }, 'ok'],
+        [BigInt(123), '123'],
+        ['abc', 'abc'],
+    ],
+    invalidConversions: [
+        [null, 'error in parser of [string.autoCast]: could not autocast value: null'],
+        [undefined, 'error in parser of [string.autoCast]: could not autocast value: undefined'],
+        [Symbol('abc'), 'error in parser of [string.autoCast]: could not autocast value: [Symbol: abc]'],
+        [Symbol.iterator, 'error in parser of [string.autoCast]: could not autocast value: [Symbol: Symbol.iterator]'],
+        [{ prop: 'value' }, 'error in parser of [string.autoCast]: could not autocast value: { prop: "value" }'],
+        [{ toString: () => 'ok' }, 'error in parser of [string.autoCast]: could not autocast value: "ok"'],
+        [function myFunc() {}, 'error in parser of [string.autoCast]: could not autocast value: [Function: myFunc]'],
     ],
 });
 test('no autoCastAll', () => {

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -1,3 +1,4 @@
+import { autoCastFailure } from '..';
 import type { Branded, StringTypeConfig, Type } from '../interfaces';
 import { SimpleType } from '../simple-type';
 import { evalAdditionalChecks, stringStringify } from '../utils';
@@ -26,7 +27,17 @@ export const string: Type<string, StringTypeConfig> = SimpleType.create<string, 
         );
     },
     {
-        autoCaster: String,
+        autoCaster: value => {
+            switch (typeof value) {
+                case 'bigint':
+                case 'boolean':
+                case 'number':
+                case 'string':
+                    return value.toString();
+                default:
+                    return autoCastFailure;
+            }
+        },
         typeConfig: {},
         acceptVisitor: (type, visitor) => visitor.visitStringType(type),
         maybeStringify: stringStringify,


### PR DESCRIPTION
See rationale in #47.

BREAKING CHANGE: `string.autoCast` no longer supports `null`, `undefined`, symbols, objects and functions and anything other than strings, numbers and booleans really.